### PR TITLE
Make the run() method of the Web UI blocking

### DIFF
--- a/pyanaconda/ui/cockpit/__init__.py
+++ b/pyanaconda/ui/cockpit/__init__.py
@@ -16,6 +16,9 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+
+import time
+
 from pyanaconda import ui
 from pyanaconda.core.constants import QUIT_MESSAGE
 from pyanaconda.core.util import startProgram
@@ -72,7 +75,17 @@ class CockpitUserInterface(ui.UserInterface):
 
     def run(self):
         """Run the interface."""
-        return startProgram(["/usr/libexec/cockpit-desktop", "/cockpit/@localhost/anaconda-webui/index.html"], reset_lang=False)
+        log.debug("web-ui: starting cockpit web view")
+        startProgram(["/usr/libexec/cockpit-desktop", "/cockpit/@localhost/anaconda-webui/index.html"], reset_lang=False)
+        log.debug("cockpit web view has been started")
+        # at the moment all the other components expect the UI run() method to be
+        # blocking, so make sure this is the case for the Web UI as well
+        # FIXME: make it possible to stop blocking once Web UI supports shutdown
+        log.debug("web-ui: cockpit web view has been started")
+        log.debug("web-ui: blocking the run() method")
+        time.sleep(100000000)
+        log.debug("web-ui: blocking the run() method - done")
+        return
 
     @property
     def meh_interface(self):


### PR DESCRIPTION
Both our existing UIs run their main loop in the run() method,
resulting in blocking as long as the UI main loop is running.

In our case we just start the web-view application in the run method,
so also add a very long sleep() call to emulate the expected run()
blocking behavior.

This seems to fix both the need to switch to tty6 manually as well
removes the need to pass inst.nokill on boot command line.