### PR TITLE
Add npm and git dependencies to the ci and rpm containers

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -37,6 +37,7 @@ RUN set -ex; \
   /usr/bin/xargs \
   rpm-build \
   git \
+  npm \
   bzip2 \
   rpm-ostree \
   pykickstart \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -28,6 +28,8 @@ RUN set -ex; \
   dnf update -y; \
   dnf install -y \
   'dnf-command(copr)' \
+  git \
+  npm \
   curl \
   python3-pip \
   /usr/bin/xargs \


### PR DESCRIPTION
Since the new cockpit plugin was introduced, we need npm and git to run
make dist, as the anaconda tarball now contains the bundled cockpit
code.