### PR TITLE
Add target for fetching cockpit's testing library in anaconda-webui Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ tests/rpm_tests/.cache/
 # these files are temporary files for cockpit
 pyanaconda/ui/cockpit/anaconda-webui/node_modules
 pyanaconda/ui/cockpit/anaconda-webui/dist
+pyanaconda/ui/cockpit/anaconda-webui/test/common/
+pyanaconda/ui/cockpit/anaconda-webui/bots/

--- a/pyanaconda/ui/cockpit/anaconda-webui/Makefile.am
+++ b/pyanaconda/ui/cockpit/anaconda-webui/Makefile.am
@@ -49,6 +49,21 @@ $(LIB_TEST):
 	mv tmp/cockpit/pkg/lib src/
 	rm -rf tmp/cockpit
 
+# checkout Cockpit's bots for standard test VM images and API to launch them
+# must be from main, as only that has current and existing images; but testvm.py API is stable
+# support CI testing against a bots change
+bots:
+	git clone --quiet --reference-if-able $${XDG_CACHE_HOME:-$$HOME/.cache}/cockpit-project/bots https://github.com/cockpit-project/bots.git
+	if [ -n "$$COCKPIT_BOTS_REF" ]; then git -C bots fetch --quiet --depth=1 origin "$$COCKPIT_BOTS_REF"; git -C bots checkout --quiet FETCH_HEAD; fi
+	@echo "checked out bots/ ref $$(git -C bots rev-parse HEAD)"
+
+# checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
+# when you start a new project, use the latest release, and update it from time to time
+test/common:
+	git clone -b 258 --depth=1 https://github.com/cockpit-project/cockpit.git tmp/cockpit
+	mv tmp/cockpit/test/common test/common
+	rm -rf tmp/cockpit
+
 package-lock.json: package.json
 	rm -f package-lock.json
 	env -u NODE_ENV npm install

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/app.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/app.jsx
@@ -58,6 +58,7 @@ export const Application = () => {
                                 <DescriptionListDescription>
                                     {prop === 'NTPEnabled'
                                         ? <Switch
+                                            id='switch-ntp-enabled'
                                             isChecked={timezoneProps[prop]}
                                             label='On'
                                             labelOff='Off'

--- a/pyanaconda/ui/cockpit/anaconda-webui/test/check-basic
+++ b/pyanaconda/ui/cockpit/anaconda-webui/test/check-basic
@@ -1,0 +1,79 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+# import Cockpit's machinery for test VMs and its browser test API
+TEST_DIR = os.path.dirname(__file__)
+sys.path.append(os.path.join(TEST_DIR, "common"))
+sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+
+from testlib import MachineCase, nondestructive, test_main  # noqa
+
+
+TIMEZONE_INTERFACE = "org.fedoraproject.Anaconda.Modules.Timezone"
+TIMEZONE_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Timezone"
+
+
+@nondestructive
+class TestAnacondaWebUI(MachineCase):
+
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        bus_address = m.execute("cat /run/anaconda/bus.address")
+        get_ntp_enabled_cmd = (
+            f'dbus-send --print-reply --bus="{bus_address}" \
+              --dest={TIMEZONE_INTERFACE} \
+              {TIMEZONE_OBJECT_PATH} \
+              org.freedesktop.DBus.Properties.Get \
+              string:"{TIMEZONE_INTERFACE}" string:"NTPEnabled"'
+        )
+        set_ntp_enabled_cmd = (
+            lambda value: f'dbus-send --print-reply --bus="{bus_address}" \
+              --dest={TIMEZONE_INTERFACE} \
+              {TIMEZONE_OBJECT_PATH} \
+              {TIMEZONE_INTERFACE}.SetNTPEnabled \
+              boolean:"{value}"'
+        )
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+        b.wait_in_text(".pf-c-card__title", "Anaconda Web UI")
+
+        # Read NTPEnabled property from the DBUS API
+        # and make sure it matches the value displayed in the WebUI
+        ntp_enabled = m.execute(get_ntp_enabled_cmd)
+        self.assertIn("boolean true", ntp_enabled)
+        b.wait_visible("#switch-ntp-enabled:checked")
+
+        # Change NTPEnabled property from the WebUI
+        # and make sure the change it reflected in the CLI
+        b.click("#switch-ntp-enabled")
+        b.wait_visible("#switch-ntp-enabled:not(checked)")
+        ntp_enabled_new = m.execute(get_ntp_enabled_cmd)
+        self.assertIn("boolean false", ntp_enabled_new)
+
+        # Change NTPEnabled property from the CLI
+        # and make sure the change is reflected in the WebUI
+        m.execute(set_ntp_enabled_cmd("true"))
+        b.wait_visible("#switch-ntp-enabled:checked")
+
+
+if __name__ == '__main__':
+    test_main()


### PR DESCRIPTION
Also add the first test file which can be now invoked manually and run
against a machine running the anaconda new web ui.

This test can be run like this:

1. Run a VM with this anaconda branch
2. Login to the VM and run a new cockpit-ws instance:
   /usr/libexec/cockpit-ws --no-tls --port 9090 --local-session=cockpit-bridge
   This will allow us to connect from the browser of the machine running
   the test to the VM
3. Find the IP adress of the VM running anaconda,
   ex: sudo virsh domifaddr cockpit-new-ui-VM
4. Run the test:
   TEST_SHOW_BROWSER=true TEST_RUNNING_INSTALLER=true ./test/check-basic -st --machine 192.168.122.124
   Replace the IP address passed to --machine CLI option.
   TEST_SHOW_BROWSER=true is not needed, it just spawns a browser
   for interactive testing and makes debugging easy. If not passed, the
   test will run in headless mode.

Until https://github.com/cockpit-project/bots/pull/2717 is merged one
needs to cherry-pick this commit into the bots checkout for testing to
work.