### PR TITLE
cockpit: Introduce template react components for all configuration subpages

### DIFF
--- a/pyanaconda/ui/cockpit/anaconda-webui/.eslintrc.json
+++ b/pyanaconda/ui/cockpit/anaconda-webui/.eslintrc.json
@@ -34,7 +34,8 @@
 
         "comma-dangle": "off",
         "no-console": "off",
-        "react/jsx-closing-bracket-location": "off"
+        "react/jsx-closing-bracket-location": "off",
+        "react/prop-types": "off"
     },
     "globals": {
         "require": false,

--- a/pyanaconda/ui/cockpit/anaconda-webui/Makefile.am
+++ b/pyanaconda/ui/cockpit/anaconda-webui/Makefile.am
@@ -23,6 +23,8 @@ LIB_TEST=src/lib/cockpit-po-plugin.js
 WEBPACK_TEST=dist/manifest.json
 WEBPACK_TEST_PRODUCTION=dist/index.css.gz
 PACKAGE_NAME=anaconda-webui
+# stamp file to check if/when npm install ran
+NODE_MODULES_TEST=package-lock.json
 ISO_FILE=test/boot.iso
 
 # makes sure it gets built as part of `make` and `make dist`
@@ -33,7 +35,7 @@ dist_noinst_DATA = \
 	package.json \
 	webpack.config.js
 
-$(WEBPACK_TEST): $(LIB_TEST) $(shell find src/ -type f) package-lock.json webpack.config.js
+$(WEBPACK_TEST): $(LIB_TEST) $(shell find src/ -type f) $(NODE_MODULES_TEST) package.json webpack.config.js
 	NODE_ENV=production $(CURDIR)/node_modules/.bin/webpack
 
 install-data-hook: $(WEBPACK_TEST)
@@ -75,7 +77,7 @@ test/common:
 	mv tmp/cockpit/test/common test/common
 	rm -rf tmp/cockpit
 
-package-lock.json: package.json
-	rm -f package-lock.json
-	env -u NODE_ENV npm install
+$(NODE_MODULES_TEST): package.json
+	rm -f package-lock.json #  if it exists already, npm install won't update it; force that so that we always get up-to-date packages
+	env -u NODE_ENV npm install #  unset NODE_ENV, skips devDependencies otherwise
 	env -u NODE_ENV npm prune

--- a/pyanaconda/ui/cockpit/anaconda-webui/Makefile.am
+++ b/pyanaconda/ui/cockpit/anaconda-webui/Makefile.am
@@ -34,7 +34,7 @@ dist_noinst_DATA = \
 	webpack.config.js
 
 $(WEBPACK_TEST): $(LIB_TEST) $(shell find src/ -type f) package-lock.json webpack.config.js
-	NODE_ENV=production node_modules/.bin/webpack
+	NODE_ENV=production $(CURDIR)/node_modules/.bin/webpack
 
 install-data-hook: $(WEBPACK_TEST)
 	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/Common.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/Common.jsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { createContext } from 'react';
+
+import {
+    Button,
+    Level,
+    PageSection, PageSectionVariants,
+    Title,
+} from '@patternfly/react-core';
+
+import { usePageLocation } from 'hooks';
+
+export const AddressContext = createContext('');
+
+export const Header = ({ done, title }) => {
+    const { path } = usePageLocation();
+    const pageId = path[0];
+
+    return (
+        <PageSection variant={pageId === 'summary' ? PageSectionVariants.light : PageSectionVariants.darker}>
+            <Level hasGutter>
+                {pageId !== 'summary' &&
+                <Button
+                  id='header-done-btn'
+                  variant='primary'
+                  onClick={done}>
+                    Done
+                </Button>}
+                <Title headingLevel='h1' size='2xl'>
+                    {title || 'Subpage description'}
+                </Title>
+                <Button
+                  id={'help-btn-' + pageId}
+                  variant='secondary'
+                  onClick={() => console.log('I am on pageId ' + (pageId || 'summary'))}>
+                    Help
+                </Button>
+            </Level>
+        </PageSection>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/InstallationDestination.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/InstallationDestination.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from 'react';
+
+import {
+    PageSection
+} from '@patternfly/react-core';
+
+import { Header } from './Common.jsx';
+
+export const InstallationDestination = () => {
+    const onDoneClicked = () => {
+        cockpit.location.go(['summary']);
+    };
+
+    return (
+        <>
+            <Header
+              done={onDoneClicked}
+              title='Installation destination'
+            />
+            <PageSection>
+                Not implemented
+            </PageSection>
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/InstallationLanguage.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/InstallationLanguage.jsx
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from 'react';
+
+import {
+    ActionGroup,
+    Button,
+    Form, FormGroup,
+    Menu, MenuContent, MenuList, MenuInput, MenuItem, Divider, DrilldownMenu,
+    PageSection,
+    TextInput, Title,
+} from '@patternfly/react-core';
+
+import './InstallationLanguage.scss';
+
+// Use this untill we can use the API to get the language listings
+const menuItems = {
+    english: {
+        label: 'English',
+        subgroup: {
+            enUS: {
+                label: 'United States'
+            },
+            enUK: {
+                label: 'United Kingdom'
+            }
+        }
+    },
+    de: {
+        label: 'Deutsch',
+        subgroup: {
+            deDE: {
+                label: 'Deutschland'
+            },
+            deLU: {
+                label: 'Luxemburg'
+            }
+        }
+    }
+};
+
+const LanguageSelector = ({ defaultLang, onSelectLang }) => {
+    const [activeItem, setActiveItem] = useState(defaultLang);
+    const [activeMenu, setActiveMenu] = useState('languageMenu');
+    const [drilldownPath, setDrilldownPath] = useState([]);
+    const [filterText, setFilterText] = useState('');
+    const [menuDrilledIn, setMenuDrilledIn] = useState([]);
+    const [menuHeights, setMenuHeights] = useState([]);
+    const [selectedItem, setSelectedItem] = useState(defaultLang);
+
+    const handleDrillIn = (fromMenuId, toMenuId, pathId) => {
+        setMenuDrilledIn([...menuDrilledIn, fromMenuId]);
+        setDrilldownPath([...drilldownPath, pathId]);
+        setActiveMenu(toMenuId);
+    };
+    const handleDrillOut = toMenuId => {
+        const menuDrilledInSansLast = menuDrilledIn.slice(0, menuDrilledIn.length - 1);
+        const pathSansLast = drilldownPath.slice(0, drilldownPath.length - 1);
+
+        setMenuDrilledIn(menuDrilledInSansLast);
+        setDrilldownPath(pathSansLast);
+        setActiveItem(toMenuId);
+    };
+    const handleSetHeight = (menuId, height) => {
+        if (!menuHeights[menuId]) {
+            setMenuHeights({
+                ...menuHeights,
+                [menuId]: height
+            });
+        }
+    };
+    const handleOnSelect = (event, itemId) => {
+        if (Object.keys(menuItems).includes(itemId)) {
+            return;
+        }
+
+        onSelectLang(itemId);
+        setActiveItem(itemId);
+        setSelectedItem(itemId);
+    };
+    const getNestedItemLabel = (groupLabel, itemLabel) => {
+        return groupLabel + ' (' + itemLabel + ')';
+    };
+
+    return (
+        <Menu
+          id='languageMenu'
+          className='language-menu'
+          containsDrilldown
+          drilldownItemPath={drilldownPath}
+          drilledInMenus={menuDrilledIn}
+          activeMenu={activeMenu}
+          onSelect={handleOnSelect}
+          activeItemId={activeItem}
+          selected={selectedItem}
+          onDrillIn={handleDrillIn}
+          onDrillOut={handleDrillOut}
+          onGetMenuHeight={handleSetHeight}
+        >
+            <MenuInput>
+                <TextInput
+                  aria-label='Filter menu items'
+                  iconVariant='search'
+                  onChange={setFilterText}
+                  type='search'
+                  value={filterText}
+                />
+            </MenuInput>
+            <Divider />
+            <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
+                <MenuList>
+                    {Object.keys(menuItems)
+                            .filter(groupKey => !filterText || drilldownPath.length || menuItems[groupKey].label.toLowerCase().includes(filterText.toLowerCase()))
+                            .map(groupKey => {
+                                const group = menuItems[groupKey];
+                                const groupLabel = group.label;
+
+                                return (
+                                    <MenuItem
+                                      itemId={groupKey}
+                                      key={groupKey}
+                                      direction='down'
+                                      drilldownMenu={
+                                          <DrilldownMenu id={'drilldownMenu_' + groupKey}>
+                                              <MenuItem itemId={groupKey} direction='up'>
+                                                  {groupLabel}
+                                              </MenuItem>
+                                              <Divider component='li' />
+                                              {Object.keys(menuItems[groupKey].subgroup)
+                                                      .filter(itemKey => {
+                                                          return (
+                                                              !filterText || !drilldownPath.length ||
+                                                              getNestedItemLabel(groupLabel, group.subgroup[itemKey].label).toLowerCase()
+                                                                      .includes(filterText.toLowerCase())
+                                                          );
+                                                      })
+                                                      .map(itemKey => {
+                                                          return (
+                                                              <MenuItem itemId={itemKey} key={itemKey}>
+                                                                  {getNestedItemLabel(groupLabel, group.subgroup[itemKey].label)}
+                                                              </MenuItem>
+                                                          );
+                                                      })}
+                                          </DrilldownMenu>
+                                      }
+                                    >
+                                        {groupLabel}
+                                    </MenuItem>
+                                );
+                            })}
+                </MenuList>
+            </MenuContent>
+        </Menu>
+    );
+};
+
+export const InstallationLanguage = ({ onSelectLang }) => {
+    const [lang, setLang] = useState('enUS');
+
+    const handleOnContinue = () => onSelectLang(lang);
+
+    return (
+        <PageSection>
+            <Form>
+                <Title headingLevel='h2' size='1xl'>
+                    WELCOME TO FEDORA...
+                </Title>
+                <FormGroup label='What language would you like to use during the installation process?'>
+                    <LanguageSelector defaultLang='enUS' onSelectLang={setLang} />
+                </FormGroup>
+                <ActionGroup>
+                    <Button id='continue-btn' variant='primary' onClick={handleOnContinue}>Continue</Button>
+                    <Button variant='link'>Quit</Button>
+                </ActionGroup>
+            </Form>
+        </PageSection>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/InstallationLanguage.scss
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/InstallationLanguage.scss
@@ -1,0 +1,4 @@
+.language-menu.pf-c-menu {
+    width: 30rem;
+    height: 30rem;
+}

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/InstallationSource.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/InstallationSource.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from 'react';
+
+import {
+    PageSection
+} from '@patternfly/react-core';
+
+import { Header } from './Common.jsx';
+
+export const InstallationSource = () => {
+    const onDoneClicked = () => {
+        cockpit.location.go(['summary']);
+    };
+
+    return (
+        <>
+            <Header
+              done={onDoneClicked}
+              title='Installation source'
+            />
+            <PageSection>
+                Not implemented
+            </PageSection>
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/Keyboard.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/Keyboard.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from 'react';
+
+import {
+    PageSection
+} from '@patternfly/react-core';
+
+import { Header } from './Common.jsx';
+
+export const Keyboard = () => {
+    const onDoneClicked = () => {
+        cockpit.location.go(['summary']);
+    };
+
+    return (
+        <>
+            <Header
+              done={onDoneClicked}
+              title='Keyboard'
+            />
+            <PageSection>
+                Not implemented
+            </PageSection>
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/Language.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/Language.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from 'react';
+
+import {
+    PageSection
+} from '@patternfly/react-core';
+
+import { Header } from './Common.jsx';
+
+export const Language = () => {
+    const onDoneClicked = () => {
+        cockpit.location.go(['summary']);
+    };
+
+    return (
+        <>
+            <Header
+              done={onDoneClicked}
+              title='Language'
+            />
+            <PageSection>
+                Not implemented
+            </PageSection>
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/NetworkHostname.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/NetworkHostname.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from 'react';
+
+import {
+    PageSection
+} from '@patternfly/react-core';
+
+import { Header } from './Common.jsx';
+
+export const NetworkHostname = () => {
+    const onDoneClicked = () => {
+        cockpit.location.go(['summary']);
+    };
+
+    return (
+        <>
+            <Header
+              done={onDoneClicked}
+              title='Network & Host Name'
+            />
+            <PageSection>
+                Not implemented
+            </PageSection>
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/RootAccount.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/RootAccount.jsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React, { useState, useContext, useEffect } from 'react';
+
+import {
+    Checkbox,
+    Form, FormGroup,
+    PageSection,
+} from '@patternfly/react-core';
+
+import { useEvent, useObject } from 'hooks';
+
+import { password_quality as passwordQuality, PasswordFormFields } from 'cockpit-components-password.jsx';
+import { AddressContext, Header } from './Common.jsx';
+
+export const RootAccount = () => {
+    const [errors, setErrors] = useState({});
+    const [isLocked, setIsLocked] = useState();
+    const [pwd, setPwd] = useState('');
+    const [pwdConfirm, setPwdConfirm] = useState('');
+    const [pwdMessage, setPwdMessage] = useState('');
+    const [pwdStrength, setPwdStrength] = useState('');
+    const address = useContext(AddressContext);
+
+    const usersProxy = useObject(() => {
+        const client = cockpit.dbus('org.fedoraproject.Anaconda.Modules.Users', { superuser: 'try', bus: 'none', address });
+        const proxy = client.proxy(
+            'org.fedoraproject.Anaconda.Modules.Users',
+            '/org/fedoraproject/Anaconda/Modules/Users',
+        );
+        setIsLocked(proxy.IsRootAccountLocked);
+
+        return proxy;
+    }, null, [address]);
+
+    useEvent(usersProxy, 'changed', (event, data) => {
+        setIsLocked(data.IsRootAccountLocked);
+    });
+
+    useEffect(() => {
+        if (pwd) {
+            passwordQuality(pwd)
+                    .then(strength => {
+                        setErrors({});
+                        setPwdStrength(strength.value);
+                        setPwdMessage(strength.message || '');
+                    })
+                    .catch(ex => {
+                        const errors = {};
+                        errors.pwd = (ex.message || ex.toString()).replace('\n', ' ');
+                        setErrors(errors);
+                        setPwdStrength(0);
+                        setPwdMessage('');
+                    });
+        } else {
+            setPwdStrength('');
+        }
+    }, [pwd]);
+
+    const onPwdChange = (type, value) => {
+        if (type === 'password') {
+            setPwd(value);
+        }
+        if (type === 'password_confirm') {
+            setPwdConfirm(value);
+        }
+    };
+
+    const onDoneClicked = () => {
+        usersProxy.SetRootAccountLocked(isLocked);
+        // TODO Set crypted root password
+        cockpit.location.go(['summary']);
+    };
+
+    return (
+        <>
+            <Header
+              done={onDoneClicked}
+              title='Root password'
+            />
+            <PageSection>
+                <Form isHorizontal>
+                    <PasswordFormFields
+                      change={onPwdChange}
+                      error_password={errors && errors.pwd}
+                      idPrefix='root-account-set-pwd'
+                      password={pwd}
+                      password_confirm={pwdConfirm}
+                      password_confirm_label='Confirm root password'
+                      password_label='Root password'
+                      password_message={pwdMessage}
+                      password_strength={pwdStrength}
+                    />
+                    <FormGroup fieldId='root-account-lock'>
+                        <Checkbox
+                          id='root-account-lock'
+                          isChecked={isLocked}
+                          isDisabled={isLocked === undefined}
+                          label='Lock root account'
+                          onChange={setIsLocked}
+                        />
+                    </FormGroup>
+                </Form>
+            </PageSection>
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/SoftwareSelection.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/SoftwareSelection.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from 'react';
+
+import {
+    PageSection
+} from '@patternfly/react-core';
+
+import { Header } from './Common.jsx';
+
+export const SoftwareSelection = () => {
+    const onDoneClicked = () => {
+        cockpit.location.go(['summary']);
+    };
+
+    return (
+        <>
+            <Header
+              done={onDoneClicked}
+              title='Software selection'
+            />
+            <PageSection>
+                Not implemented
+            </PageSection>
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/Summary.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/Summary.jsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from 'react';
+
+import {
+    ActionGroup,
+    Alert,
+    Button,
+    Form,
+    Gallery,
+    HelperText, HelperTextItem,
+    PageSection,
+    Stack,
+    Tile,
+    Title,
+} from '@patternfly/react-core';
+import {
+    BellIcon,
+    BookIcon,
+    ClockIcon,
+    FlavorIcon,
+    KeyIcon,
+    KeyboardIcon,
+    NetworkIcon,
+    UserIcon,
+} from '@patternfly/react-icons';
+
+import { Header } from './Common.jsx';
+import { InstallationDestination } from './InstallationDestination.jsx';
+import { InstallationSource } from './InstallationSource.jsx';
+import { Keyboard } from './Keyboard.jsx';
+import { Language } from './Language.jsx';
+import { NetworkHostname } from './NetworkHostname.jsx';
+import { RootAccount } from './RootAccount.jsx';
+import { SoftwareSelection } from './SoftwareSelection.jsx';
+import { TimeDate } from './TimeDate.jsx';
+import { UserAccount } from './UserAccount.jsx';
+import { usePageLocation } from 'hooks';
+
+import './Summary.scss';
+
+export const Summary = () => {
+    const { path } = usePageLocation();
+    const onSelect = event => {
+        cockpit.location.go([event.currentTarget.id]);
+    };
+
+    let subpage;
+    if (path[0] === 'keyboard') {
+        subpage = <Keyboard />;
+    } else if (path[0] === 'language') {
+        subpage = <Language />;
+    } else if (path[0] === 'timedate') {
+        subpage = <TimeDate />;
+    } else if (path[0] === 'installation-source') {
+        subpage = <InstallationSource />;
+    } else if (path[0] === 'software-selection') {
+        subpage = <SoftwareSelection />;
+    } else if (path[0] === 'installation-destination') {
+        subpage = <InstallationDestination />;
+    } else if (path[0] === 'network-hostname') {
+        subpage = <NetworkHostname />;
+    } else if (path[0] === 'root-account') {
+        subpage = <RootAccount />;
+    } else if (path[0] === 'user-account') {
+        subpage = <UserAccount />;
+    }
+
+    return (
+        <>
+            {path[0] === 'summary' && <Header title='Installation summary' />}
+            {path[0] === 'summary' &&
+            <PageSection className='summary'>
+                <Form>
+                    <Gallery hasGutter>
+                        <Stack hasGutter>
+                            <Title headingLevel='h1' size='2xl'>
+                                Localization
+                            </Title>
+                            <Tile onClick={onSelect} id='keyboard' title='Keyboard' icon={<KeyboardIcon />} isStacked>
+                                FILLME
+                            </Tile>
+                            <Tile onClick={onSelect} id='language' title='Language support' icon={<BookIcon />} isStacked>
+                                FILLME
+                            </Tile>
+                            <Tile onClick={onSelect} id='timedate' title='Time & Date' icon={<ClockIcon />} isStacked>
+                                FILLME
+                            </Tile>
+                        </Stack>
+                        <Stack hasGutter>
+                            <Title headingLevel='h1' size='2xl'>
+                                Software
+                            </Title>
+                            <Tile onClick={onSelect} id='installation-source' title='Installation source' icon={<BellIcon />} isStacked>
+                                FILLME
+                            </Tile>
+                            <Tile onClick={onSelect} id='software-selection' title='Software Selection' icon={<FlavorIcon />} isStacked>
+                                FILLME
+                            </Tile>
+                        </Stack>
+                        <Stack hasGutter>
+                            <Title headingLevel='h1' size='2xl'>
+                                System
+                            </Title>
+                            <Tile onClick={onSelect} id='installation-destination' title='Installation destination' icon={<BellIcon />} isStacked>
+                                FILLME
+                            </Tile>
+                            <Tile onClick={onSelect} id='network-hostname' title='Network & Host name' icon={<NetworkIcon />} isStacked>
+                                FILLME
+                            </Tile>
+                        </Stack>
+                        <Stack hasGutter>
+                            <Title headingLevel='h1' size='2xl'>
+                                User settings
+                            </Title>
+                            <Tile onClick={onSelect} id='root-account' title='Root password' icon={<KeyIcon />} isStacked>
+                                <HelperText>
+                                    <HelperTextItem variant='warning' hasIcon>Root account is disabled</HelperTextItem>
+                                </HelperText>
+                            </Tile>
+                            <Tile onClick={onSelect} id='user-account' title='User creation' icon={<UserIcon />} isStacked>
+                                <HelperText>
+                                    <HelperTextItem variant='warning' hasIcon>No user will be created</HelperTextItem>
+                                </HelperText>
+                            </Tile>
+                        </Stack>
+                    </Gallery>
+                    <Alert variant='warning' isInline title='Please complete items marked with this icon before continuing to the next step' />
+                    <ActionGroup>
+                        <Button id='begin-installation-btn' variant='primary' isDisabled>Begin installation</Button>
+                        <Button variant='link'>Quit</Button>
+                        <HelperText className='action-hint'>
+                            <HelperTextItem variant='indeterminate'>We won't touch your disks until you click 'Begin installation'</HelperTextItem>
+                        </HelperText>
+                    </ActionGroup>
+                </Form>
+            </PageSection>}
+            {path[0] !== 'summary' && subpage}
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/Summary.scss
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/Summary.scss
@@ -1,0 +1,14 @@
+.summary {
+    .action-hint {
+        // Let action hint wrap to the next line
+        width: 100%;
+        // And remote redundant margin that the component has
+        margin-top: 0;
+    }
+
+    // Align hint items in the center of the flex container
+    .pf-c-tile .pf-c-helper-text__item {
+      align-items: center;
+      justify-content: center;
+    }
+}

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/TimeDate.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/TimeDate.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from 'react';
+
+import {
+    PageSection
+} from '@patternfly/react-core';
+
+import { Header } from './Common.jsx';
+
+export const TimeDate = () => {
+    const onDoneClicked = () => {
+        cockpit.location.go(['summary']);
+    };
+
+    return (
+        <>
+            <Header
+              done={onDoneClicked}
+              title='Time & Date'
+            />
+            <PageSection>
+                Not implemented
+            </PageSection>
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/UserAccount.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/UserAccount.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from 'cockpit';
+import React from 'react';
+
+import {
+    PageSection
+} from '@patternfly/react-core';
+
+import { Header } from './Common.jsx';
+
+export const UserAccount = () => {
+    const onDoneClicked = () => {
+        cockpit.location.go(['summary']);
+    };
+
+    return (
+        <>
+            <Header
+              done={onDoneClicked}
+              title='Create user'
+            />
+            <PageSection>
+                Not implemented
+            </PageSection>
+        </>
+    );
+};

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/app.jsx
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/app.jsx
@@ -1,76 +1,45 @@
 /*
- * This file is part of Cockpit.
- *
  * Copyright (C) 2021 Red Hat, Inc.
  *
- * Cockpit is free software; you can redistribute it and/or modify it
+ * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
  *
- * Cockpit is distributed in the hope that it will be useful, but
+ * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
  */
-
 import cockpit from 'cockpit';
 import React, { useEffect, useState } from 'react';
+
 import {
-    Card, CardBody, CardTitle,
-    DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
-    Switch,
+    Page,
 } from '@patternfly/react-core';
 
-import { useEvent, useObject } from 'hooks';
+import { InstallationLanguage } from './InstallationLanguage.jsx';
+import { Summary } from './Summary.jsx';
+import { AddressContext } from './Common.jsx';
+
+import { usePageLocation } from 'hooks';
 
 export const Application = () => {
-    const [timezoneProps, setTimezoneProps] = useState();
     const [address, setAddress] = useState();
+    const { path } = usePageLocation();
 
-    const timezoneProxy = useObject(() => {
-        const client = cockpit.dbus('org.fedoraproject.Anaconda.Modules.Timezone', { superuser: 'try', bus: 'none', address });
-        const proxy = client.proxy(
-            'org.fedoraproject.Anaconda.Modules.Timezone',
-            '/org/fedoraproject/Anaconda/Modules/Timezone',
-        );
-        setTimezoneProps(proxy.data);
-
-        return proxy;
-    }, null, [address]);
-
-    useEvent(timezoneProxy, 'changed', (event, data) => setTimezoneProps(data));
     useEffect(() => cockpit.file('/run/anaconda/bus.address').watch(setAddress), []);
 
     return (
-        <Card>
-            <CardTitle>Anaconda Web UI</CardTitle>
-            <CardBody>
-                {timezoneProps &&
-                <DescriptionList isHorizontal>
-                    {Object.keys(timezoneProps).map(prop => {
-                        return (
-                            <DescriptionListGroup key={prop}>
-                                <DescriptionListTerm>{prop}</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    {prop === 'NTPEnabled'
-                                        ? <Switch
-                                            id='switch-ntp-enabled'
-                                            isChecked={timezoneProps[prop]}
-                                            label='On'
-                                            labelOff='Off'
-                                            onChange={enabled => timezoneProxy.SetNTPEnabled(enabled)}
-                                        />
-                                        : timezoneProps[prop].toString()}
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                        );
-                    })}
-                </DescriptionList>}
-            </CardBody>
-        </Card>
+        <Page>
+            {!path.length > 0 && <InstallationLanguage onSelectLang={() => cockpit.location.go(['summary'])} />}
+            {path.length > 0 &&
+            <AddressContext.Provider value={address}>
+                <Summary />
+            </AddressContext.Provider>}
+        </Page>
     );
 };

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/app.scss
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/app.scss
@@ -1,3 +1,1 @@
-p {
-    font-weight: bold;
-}
+@import 'page.scss';

--- a/pyanaconda/ui/cockpit/anaconda-webui/src/index.html
+++ b/pyanaconda/ui/cockpit/anaconda-webui/src/index.html
@@ -30,6 +30,6 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
 </head>
 
 <body class="pf-m-redhat-font">
-    <div id="app"></div>
+    <div class="ct-page-fill" id="app"></div>
 </body>
 </html>

--- a/pyanaconda/ui/cockpit/anaconda-webui/test/check-basic
+++ b/pyanaconda/ui/cockpit/anaconda-webui/test/check-basic
@@ -25,55 +25,23 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 
 from testlib import MachineCase, nondestructive, test_main  # noqa
 
-
-TIMEZONE_INTERFACE = "org.fedoraproject.Anaconda.Modules.Timezone"
-TIMEZONE_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Timezone"
-
-
 @nondestructive
-class TestAnacondaWebUI(MachineCase):
+class TestBasic(MachineCase):
 
-    def testBasic(self):
+    def testHelp(self):
         b = self.browser
         m = self.machine
 
-        bus_address = m.execute("cat /run/anaconda/bus.address")
-        get_ntp_enabled_cmd = (
-            f'dbus-send --print-reply --bus="{bus_address}" \
-              --dest={TIMEZONE_INTERFACE} \
-              {TIMEZONE_OBJECT_PATH} \
-              org.freedesktop.DBus.Properties.Get \
-              string:"{TIMEZONE_INTERFACE}" string:"NTPEnabled"'
-        )
-        set_ntp_enabled_cmd = (
-            lambda value: f'dbus-send --print-reply --bus="{bus_address}" \
-              --dest={TIMEZONE_INTERFACE} \
-              {TIMEZONE_OBJECT_PATH} \
-              {TIMEZONE_INTERFACE}.SetNTPEnabled \
-              boolean:"{value}"'
-        )
-
         b.open("/cockpit/@localhost/anaconda-webui/index.html")
-        b.wait_in_text(".pf-c-card__title", "Anaconda Web UI")
 
-        # Read NTPEnabled property from the DBUS API
-        # and make sure it matches the value displayed in the WebUI
-        ntp_enabled = m.execute(get_ntp_enabled_cmd)
-        self.assertIn("boolean true", ntp_enabled)
-        b.wait_visible("#switch-ntp-enabled:checked")
+        b.click('#continue-btn')
 
-        # Change NTPEnabled property from the WebUI
-        # and make sure the change it reflected in the CLI
-        b.click("#switch-ntp-enabled")
-        b.wait_visible("#switch-ntp-enabled:not(checked)")
-        ntp_enabled_new = m.execute(get_ntp_enabled_cmd)
-        self.assertIn("boolean false", ntp_enabled_new)
-
-        # Change NTPEnabled property from the CLI
-        # and make sure the change is reflected in the WebUI
-        m.execute(set_ntp_enabled_cmd("true"))
-        b.wait_visible("#switch-ntp-enabled:checked")
-
+        for page in ['keyboard', 'language', 'timedate', 'installation-source', 'software-selection', 'installation-destination', 'network-hostname', 'root-account', 'user-account']:
+            b.click("#" + page)
+            b.wait_js_cond(f'window.location.hash === "#/{page}"')
+            b.click('#help-btn-' + page)
+            b.click('#header-done-btn')
+            # TODO replace alert with some real help popup and check the content here
 
 if __name__ == '__main__':
     test_main()

--- a/pyanaconda/ui/cockpit/anaconda-webui/test/check-root-account
+++ b/pyanaconda/ui/cockpit/anaconda-webui/test/check-root-account
@@ -1,0 +1,82 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+# import Cockpit's machinery for test VMs and its browser test API
+TEST_DIR = os.path.dirname(__file__)
+sys.path.append(os.path.join(TEST_DIR, "common"))
+sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+
+from testlib import MachineCase, nondestructive, test_main  # noqa
+
+USERS_INTERFACE = "org.fedoraproject.Anaconda.Modules.Users"
+USERS_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Users"
+
+
+@nondestructive
+class TestRootAccount(MachineCase):
+
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        bus_address = m.execute("cat /run/anaconda/bus.address")
+        get_root_account_locked_cmd = (
+            f'dbus-send --print-reply --bus="{bus_address}" \
+              --dest={USERS_INTERFACE} \
+              {USERS_OBJECT_PATH} \
+              org.freedesktop.DBus.Properties.Get \
+              string:"{USERS_INTERFACE}" string:"IsRootAccountLocked"'
+        )
+        set_root_account_locked_cmd = (
+            lambda value: f'dbus-send --print-reply --bus="{bus_address}" \
+              --dest={USERS_INTERFACE} \
+              {USERS_OBJECT_PATH} \
+              {USERS_INTERFACE}.SetRootAccountLocked \
+              boolean:"{value}"'
+        )
+
+        b.open("/cockpit/@localhost/anaconda-webui/index.html")
+
+        b.click('#continue-btn')
+        b.click('#root-account')
+
+        # Read IsRootAccountLocked property from the DBUS API
+        # and make sure it matches the value displayed in the WebUI
+        root_account_locked = m.execute(get_root_account_locked_cmd)
+        self.assertIn("boolean true", root_account_locked)
+        b.wait_visible("#root-account-lock:checked")
+
+        # Change IsRootAccountLocked property from the WebUI
+        # and make sure the change it reflected in the CLI
+        b.set_checked("#root-account-lock", False)
+        b.click('#header-done-btn')
+        root_account_locked_new = m.execute(get_root_account_locked_cmd)
+        self.assertIn("boolean false", root_account_locked_new)
+
+        # Change IsRootAccountLocked property from the CLI
+        # and make sure the change is reflected in the WebUI
+        m.execute(set_root_account_locked_cmd("true"))
+        # Go back to the root account subpage
+        b.click('#root-account')
+        b.wait_visible("#root-account-lock:checked")
+
+
+if __name__ == '__main__':
+    test_main()

--- a/pyanaconda/ui/cockpit/anaconda-webui/test/run-test
+++ b/pyanaconda/ui/cockpit/anaconda-webui/test/run-test
@@ -10,8 +10,8 @@ clean_up () {
     exit $ARG
 }
 
-trap clean_up SIGINT SIGTERM EXIT
-pushd ../../../../
+trap clean_up INT TERM EXIT
+cd ../../../../
 
 # FIXME boot.iso on rawhide does not currently contain the new cockpit dependencies
 # This will change once we include this changes upstream and start building boot.iso with the new dependencies
@@ -19,31 +19,34 @@ pushd ../../../../
 test ! -e cockpit-ws*.rpm && curl -LO https://kojipkgs.fedoraproject.org//packages/cockpit/259/1.fc35/x86_64/cockpit-ws-259-1.fc35.x86_64.rpm
 test ! -e cockpit-bridge*.rpm && curl -LO https://kojipkgs.fedoraproject.org//packages/cockpit/259/1.fc35/x86_64/cockpit-bridge-259-1.fc35.x86_64.rpm
 
-scripts/makeupdates --add $RPM_PATH/anaconda-*.rpm --add cockpit-*.rpm
+scripts/makeupdates --add "$RPM_PATH"/anaconda-*.rpm --add cockpit-*.rpm
 python3 -m http.server &
-popd
+cd pyanaconda/ui/cockpit/anaconda-webui/
+
+WAIT=""
+if ! test -z "$VM_ONLY"; then
+    WAIT="--wait -1"
+fi
 
 # Run the test VM
-virt-install --connect qemu:///session \
+eval virt-install --connect qemu:///session \
         --quiet --name test-updates \
+        "$WAIT" \
         --os-variant fedora-rawhide \
         --memory 2048 \
         --noautoconsole \
         --graphics vnc,listen=127.0.0.2 \
-        --extra-args='inst.sshd inst.nokill inst.updates=http://10.0.2.2:8000/updates.img' \
+        --extra-args="'inst.sshd inst.nokill inst.updates=http://10.0.2.2:8000/updates.img'" \
         --network none \
-        --qemu-commandline='-netdev user,id=hostnet0,hostfwd=tcp:127.0.0.2:'22000'-:22,hostfwd=tcp:127.0.0.2:9091-:9090 -device virtio-net-pci,netdev=hostnet0,id=net0' \
-        --initrd-inject `pwd`/test/ks.cfg --extra-args "inst.ks=file:/ks.cfg" \
-        --disk size=10,format=qcow2 --location $1
+        --qemu-commandline="'-netdev user,id=hostnet0,hostfwd=tcp:127.0.0.2:22000-:22,hostfwd=tcp:127.0.0.2:9091-:9090 -device virtio-net-pci,netdev=hostnet0,id=net0'" \
+        --initrd-inject "$(pwd)"/test/ks.cfg --extra-args "inst.ks=file:/ks.cfg" \
+        --disk size=10,format=qcow2 --location "$1"
 
-if ! test -z "$VM_ONLY"; then
-    ( trap exit SIGINT ; read -r -d '' _ </dev/tty ) ## wait for Ctrl-C
-    exit 0
+if test -z "$VM_ONLY"; then
+    until curl --silent -o /dev/null --head --fail http://127.0.0.2:9091/cockpit/@localhost/anaconda-webui/index.html; do
+        echo 'Waiting for anaconda UI to show up...'
+        sleep 5
+    done
+
+    TEST_ALLOW_NOLOGIN=true test/common/run-tests --jobs 1 --machine 127.0.0.2:22000 --browser 127.0.0.2:9091
 fi
-
-until $(curl --silent -o /dev/null --head --fail http://127.0.0.2:9091/cockpit/@localhost/anaconda-webui/index.html); do
-    echo 'Waiting for anaconda UI to show up...'
-    sleep 5
-done
-
-TEST_ALLOW_NOLOGIN=true test/common/run-tests --jobs 1 --machine 127.0.0.2:22000 --browser 127.0.0.2:9091

--- a/pyanaconda/ui/cockpit/anaconda-webui/test/run-test
+++ b/pyanaconda/ui/cockpit/anaconda-webui/test/run-test
@@ -46,4 +46,4 @@ until $(curl --silent -o /dev/null --head --fail http://127.0.0.2:9091/cockpit/@
     sleep 5
 done
 
-TEST_ALLOW_NOLOGIN=true test/check-basic -t --machine 127.0.0.2:22000 --browser 127.0.0.2:9091
+TEST_ALLOW_NOLOGIN=true test/common/run-tests --jobs 1 --machine 127.0.0.2:22000 --browser 127.0.0.2:9091


### PR DESCRIPTION
Also start implementing the language selection intro menu and the root
password subpage which can be now used as a code reference.

@patternfly/react-core was updated to the latest available so as to be
able to use the latest features implemented.

react/prop-types rule was disabled in eslint, as I find that PropTypes
add a lot of code and little help.

Lastly introduce a new test file for the root account subpage, and since
now we have more than one (2!!) test files, let's use the
test/common/run-test wrapper for running the tests in CI.